### PR TITLE
Add shared prettier config package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "files.exclude": {
+    "**/.git": true,
+    "**/node_modules": true,
+    "**/.DS_Store": true,
+  },
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prettier": "prettier './**/*.{md,json,yml}' --check"
   },
   "packageManager": "yarn@4.0.2",
   "devDependencies": {
-    "@changesets/cli": "^2.27.1"
-  }
+    "@changesets/cli": "^2.27.1",
+    "prettier": "^3.2.4"
+  },
+  "prettier": "@channel.io/prettier-config"
 }

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,0 +1,17 @@
+# `@channel-io/prettier-config`
+
+Shared prettier configuration
+
+## Installation
+
+```bash
+$ yarn add --dev @channel.io/prettier-config
+```
+
+## Usage
+
+Channels’s shared prettier config comes bundled in `@channel-io/prettier-config`. To enable these rules, add a `prettier` property in your `package.json` and reference this shared config as follows:
+
+```JSON
+"prettier": "@channel.io/prettier-config"
+```

--- a/packages/prettier-config/index.json
+++ b/packages/prettier-config/index.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "singleAttributePerLine": true,
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@channel.io/prettier-config",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "Shared prettier configuration",
+  "main": "index.json",
+  "sideEffects": false,
+  "author": "Channel Corp.",
+  "bugs": {
+    "url": "https://github.com/channel-io/shared-configs/issues"
+  },
+  "homepage": "https://github.com/channel-io/shared-configs/packages/prettier-config/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/channel-io/shared-configs.git",
+    "directory": "packages/prettier-config"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,6 +706,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@channel.io/prettier-config@workspace:packages/prettier-config":
+  version: 0.0.0-use.local
+  resolution: "@channel.io/prettier-config@workspace:packages/prettier-config"
+  languageName: unknown
+  linkType: soft
+
 "@channel.io/stylelint-config@workspace:packages/stylelint-config":
   version: 0.0.0-use.local
   resolution: "@channel.io/stylelint-config@workspace:packages/stylelint-config"
@@ -5734,6 +5740,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "prettier@npm:3.2.4"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 88dfeb78ac6096522c9a5b81f1413d875f568420d9bb6a5e5103527912519b993f2bcdcac311fcff5718d5869671d44e4f85827d3626f3a6ce32b9abc65d88e0
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -7226,6 +7241,7 @@ __metadata:
   resolution: "web-configs@workspace:."
   dependencies:
     "@changesets/cli": "npm:^2.27.1"
+    prettier: "npm:^3.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Create package for shared prettier config .
By adding prettier config on package.json, we could use config without generate .prettierc.

Use prettier config from Channel Desk as shared config.

Add .vscode config for shared-configs to use prettier as formatting option.

Reference: [Sharing Configuartion on Prettier](https://prettier.io/docs/en/configuration.html#sharing-configurations)