### PR TITLE
Add typescript-config

### DIFF
--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,1 @@
+# typescript-config

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/packages/typescript-config/node-library.json
+++ b/packages/typescript-config/node-library.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./node.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/typescript-config/node.json
+++ b/packages/typescript-config/node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "node16",
+    "target": "es2022",
+    "lib": ["es2022"]
+  }
+}

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,10 +1,7 @@
 {
   "name": "@channel.io/typescript-config",
   "version": "0.0.1",
-  "description": "Typescript configuration for channel.io web",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "description": "Typescript configuration for Channel.io",
   "author": "Channel Corp.",
   "bugs": {
     "url": "https://github.com/channel-io/shared-config/issues"

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@channel.io/typescript-config",
+  "version": "0.0.1",
+  "description": "Typescript configuration for channel.io web",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Channel Corp.",
+  "bugs": {
+    "url": "https://github.com/channel-io/shared-config/issues"
+  },
+  "homepage": "https://github.com/channel-io/shared-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/channel-io/shared-config.git"
+  },
+  "keywords": [
+    "typescript",
+    "channelio"
+  ],
+  "license": "MIT"
+}

--- a/packages/typescript-config/web-library.json
+++ b/packages/typescript-config/web-library.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./web.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/typescript-config/web.json
+++ b/packages/typescript-config/web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "es2022",
+    "target": "es2022"
+  }
+}


### PR DESCRIPTION
Add typescript configs for general usecase

For `Node`, `node-library`, `web`, and `web-library`.
Please refer to Notion for details on each property.

[Current configs that is used in Channel.io](https://www.notion.so/channelio/tsconfig-7c29e6f2b96f4f6f9ffa1174d16a1998)
[Description for tsconfig property](https://www.notion.so/channelio/tsconfig-property-Research-dea4770d3d7e4dbeb77aebf6a4c59446)