### PR TITLE
Add {} for import/resolver typescript

### DIFF
--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -44,6 +44,9 @@ module.exports = {
         'import/parsers': {
           '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
         },
+        'import/resolver': {
+          typescript: {},
+        },
       },
     },
   ],


### PR DESCRIPTION
https://github.com/import-js/eslint-plugin-import/issues/1485#issuecomment-571597574

This option should be added to the config files in order to load tsconfig for eslint.