### PR TITLE
docs: update all packages homepage / git url

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,7 +19,7 @@
     "next.js",
     "rules"
   ],
-  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-config/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-config",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/channel-io/shared-configs.git"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,7 +9,7 @@
   },
   "author": "Channel Corp.",
   "bugs": {
-    "url": "https://github.com/channel-io/eslint-config/issues"
+    "url": "https://github.com/channel-io/shared-configs/issues"
   },
   "files": [
     "README.md",
@@ -19,10 +19,10 @@
     "next.js",
     "rules"
   ],
-  "homepage": "https://github.com/channel-io/eslint-config",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-config/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/channel-io/eslint-config.git"
+    "url": "git+https://github.com/channel-io/shared-configs.git"
   },
   "keywords": [
     "react",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,12 +8,12 @@
     "test": "jest"
   },
   "bugs": {
-    "url": "https://github.com/channel-io/eslint-plugin/issues"
+    "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/eslint-plugin",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-plugin/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/channel-io/eslint-plugin.git"
+    "url": "git+https://github.com/channel-io/shared-configs.git"
   },
   "keywords": [
     "react",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-plugin/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/eslint-plugin",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/channel-io/shared-configs.git"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-configs/packages/prettier-config/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/prettier-config/README.md",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/channel-io/shared-configs.git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/prettier-config/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/prettier-config",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/channel-io/shared-configs.git",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/stylelint-config/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/stylelint-config",
   "keywords": [
     "stylelint",
     "stylelint-config",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/channel-io/stylelint-config"
+    "url": "https://github.com/channel-io/shared-configs"
   },
   "bugs": {
-    "url": "https://github.com/channel-io/stylelint-config/issues"
+    "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/stylelint-config",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/stylelint-config/README.md",
   "keywords": [
     "stylelint",
     "stylelint-config",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -4,12 +4,12 @@
   "description": "Typescript configuration for Channel.io",
   "author": "Channel Corp.",
   "bugs": {
-    "url": "https://github.com/channel-io/shared-config/issues"
+    "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-config",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/typescript-config/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/channel-io/shared-config.git"
+    "url": "git+https://github.com/channel-io/shared-configs.git"
   },
   "keywords": [
     "typescript",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/channel-io/shared-configs/issues"
   },
-  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/typescript-config/README.md",
+  "homepage": "https://github.com/channel-io/shared-configs/tree/main/packages/typescript-config",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/channel-io/shared-configs.git"


### PR DESCRIPTION
## Goals

- npm에 표시되는 홈페이지와 git url을 shared-configs를 바라보도록 업데이트 합니다.
- 올바르지 않은 경로로 표시되던 README.md 링크를 모두 수정합니다.