### PR TITLE
Apply @rushstack/eslint-patch to @channel.io/eslint-config for resolving ESLint plugin dependencies

### DIFF
--- a/.changeset/khaki-parks-burn.md
+++ b/.changeset/khaki-parks-burn.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/eslint-config': minor
+---
+
+Apply `@rushstack/eslint-patch` to resolve ESLint plugin dependencies without requiring users to install them directly

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@next/eslint-plugin-next": "^14.2.29",
+    "@rushstack/eslint-patch": "^1.11.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/eslint-config/rules/base.js
+++ b/packages/eslint-config/rules/base.js
@@ -1,3 +1,5 @@
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 module.exports = {
   parserOptions: {
     sourceType: 'module',

--- a/packages/eslint-config/rules/base.js
+++ b/packages/eslint-config/rules/base.js
@@ -7,7 +7,7 @@ module.exports = {
     ecmaFeatures: { impliedStrict: true, jsx: true },
   },
   env: { es2022: true, jest: true },
-  plugins: ['import', 'unused-imports'],
+  plugins: ['import'],
   rules: {
     'constructor-super': 'warn',
     eqeqeq: ['error', 'smart'],

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -9,7 +9,7 @@ module.exports = {
         // typescript-estree and prints a warning by default
         suppressDeprecatedPropertyWarnings: true,
       },
-      plugins: ['@typescript-eslint'],
+      plugins: ['@typescript-eslint', 'unused-imports'],
       rules: {
         '@typescript-eslint/consistent-type-imports': ['warn'],
         '@typescript-eslint/consistent-type-assertions': [

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,6 +673,7 @@ __metadata:
   resolution: "@channel.io/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@next/eslint-plugin-next": "npm:^14.2.29"
+    "@rushstack/eslint-patch": "npm:^1.11.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.32.1"
     "@typescript-eslint/parser": "npm:^8.32.1"
     eslint: "npm:^8.57.1"
@@ -1327,6 +1328,13 @@ __metadata:
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
   checksum: b5bcfb0d87f7d1c1c7c0f7693f53b07866ed9fec4c34a97a8c948fb9a7c0082e416ce4d3b60beb4f5e167cbe04cdeefbf6771320f3ede059b9ce91188c409a5b
+  languageName: node
+  linkType: hard
+
+"@rushstack/eslint-patch@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@rushstack/eslint-patch@npm:1.11.0"
+  checksum: abea8d8cf2f4f50343f74abd6a8173c521ddd09b102021f5aa379ef373c40af5948b23db0e87eca1682e559e09d97d3f0c48ea71edad682c6bf72b840c8675b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 개요

`@channel.io/eslint-config` 패키지에 `@rushstack/eslint-patch`를 적용하여 사용처에서 ESLint 플러그인을 의존성으로 설치않아도 되도록 개선합니다.

### 변경 사항

- `@channel.io/eslint-config`에 `@rushstack/eslint-patch` 적용 ([#](https://github.com/microsoft/rushstack/tree/main/eslint/eslint-patch#modern-module-resolution-feature))
- ESLint 8.21.0 버전부터는 Flat config를 사용할 경우 의존성 포함 기능을 빌트인으로 사용할 수 있는데, 마이그레이션 비용이 있어 외부 패치를 적용하는게 더 좋겠다고 판단했습니다.
- 적용 이후 사용처에서 추가한 `@channel.io/eslint-config` 의 의존성을 모두 제거할 수 있습니다. (`eslint-config-prettier` 등)
- unused-import 플러그인 위치를 가까운 타입스크립트 rule 근처로 옮깁니다.

### 테스트

데스크에 로컬로 테스트해봤을 때, `eslint-plugin-unused-imports` 를 의존성으로 추가하지 않아도 잘 동작함.
기존엔 `ESLint couldn't find the plugin "eslint-plugin-unused-imports".` 에러가 발생합니다.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/39ec5cdd-3bcd-4447-8614-4efb101ec3c3" />
