### PR TITLE
eslint-config@3.0.0

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: './node.js',
-}

--- a/packages/eslint-config/default.js
+++ b/packages/eslint-config/default.js
@@ -1,4 +1,7 @@
-module.exports = {
-  extends: ['./rules/base.js', './rules/typescript.js', './rules/prettier.js'],
-  rules: { curly: ['error', 'all'] },
-}
+const { defineConfig } = require('eslint/config')
+
+const base = require('./rules/base.js')
+const typescript = require('./rules/typescript.js')
+const prettier = require('./rules/prettier.js')
+
+module.exports = defineConfig([...base, ...typescript, ...prettier])

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,0 +1,3 @@
+const { defineConfig } = require('eslint/config')
+
+module.exports = defineConfig(require('./node.js'))

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -1,12 +1,31 @@
-module.exports = {
-  extends: [
-    './rules/base.js',
-    './rules/react.js',
-    './rules/typescript.js',
-    './rules/prettier.js',
-    './rules/next.js',
-  ],
-  env: { browser: true, node: true },
-  globals: { window: true, fetch: true },
-  rules: { curly: ['error', 'all'] },
-}
+const { defineConfig } = require('eslint/config')
+
+const globals = require('globals')
+
+const base = require('./rules/base.js')
+const react = require('./rules/react.js')
+const typescript = require('./rules/typescript.js')
+const prettier = require('./rules/prettier.js')
+const nextRules = require('./rules/next.js')
+
+module.exports = defineConfig([
+  ...base,
+  ...react,
+  ...typescript,
+  ...prettier,
+  ...nextRules,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        window: true,
+        fetch: true,
+      },
+    },
+
+    rules: {
+      curly: ['error', 'all'],
+    },
+  },
+])

--- a/packages/eslint-config/node.js
+++ b/packages/eslint-config/node.js
@@ -1,5 +1,24 @@
-module.exports = {
-  extends: ['./rules/base.js', './rules/typescript.js', './rules/prettier.js'],
-  env: { node: true },
-  rules: { curly: ['error', 'all'] },
-}
+const { defineConfig } = require('eslint/config')
+
+const globals = require('globals')
+
+const base = require('./rules/base.js')
+const typescript = require('./rules/typescript.js')
+const prettier = require('./rules/prettier.js')
+
+module.exports = defineConfig([
+  ...base,
+  ...typescript,
+  ...prettier,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+
+    rules: {
+      curly: ['error', 'all'],
+    },
+  },
+])

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@channel.io/eslint-config",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
+    "access": "public"
   },
   "engines": {
     "node": ">=18.18 || >=20"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@channel.io/eslint-config",
-  "version": "2.3.0",
+  "version": "3.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public",
+    "tag": "alpha"
+  },
+  "engines": {
+    "node": ">=18.18 || >=20"
+  },
   "description": "ESLint configuration for Channel.io web projects",
   "main": "default.js",
   "scripts": {
@@ -32,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@next/eslint-plugin-next": "^14.2.29",
-    "@rushstack/eslint-patch": "^1.11.0",
+    "@rushstack/eslint-patch": "^1.12.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "eslint-config-prettier": "^9.1.0",
@@ -41,15 +48,19 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-unused-imports": "^4.1.4"
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^16.3.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.10",
+    "eslint": ">=9 <10",
     "prettier": ">=3"
   },
   "devDependencies": {
-    "eslint": "^8.57.1",
+    "@eslint/compat": "^1.3.2",
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "^9.34.0",
+    "eslint": "^9.34.0",
     "prettier": "^3.5.3",
     "typescript": "^4.9.5"
   }

--- a/packages/eslint-config/rules/base.js
+++ b/packages/eslint-config/rules/base.js
@@ -1,124 +1,219 @@
-require('@rushstack/eslint-patch/modern-module-resolution')
+const { defineConfig } = require('eslint/config')
 
-module.exports = {
-  parserOptions: {
-    sourceType: 'module',
-    ecmaVersion: 2022,
-    ecmaFeatures: { impliedStrict: true, jsx: true },
-  },
-  env: { es2022: true, jest: true },
-  plugins: ['import'],
-  rules: {
-    'constructor-super': 'warn',
-    eqeqeq: ['error', 'smart'],
-    'getter-return': 'warn',
-    'new-parens': 'warn',
-    'no-alert': 'off',
-    'no-case-declarations': 'warn',
-    'no-compare-neg-zero': 'error',
-    'no-cond-assign': 'warn',
-    'no-const-assign': 'error',
-    'no-constant-condition': ['warn', { checkLoops: false }],
-    'no-control-regex': 'off',
-    'no-delete-var': 'error',
-    'no-dupe-args': 'error',
-    'no-dupe-class-members': 'error',
-    'no-dupe-keys': 'error',
-    'no-duplicate-case': 'error',
-    'no-empty-character-class': 'warn',
-    'no-empty-pattern': 'warn',
-    'no-eval': 'warn',
-    'no-ex-assign': 'warn',
-    'no-extend-native': 'warn',
-    'no-extra-bind': 'warn',
-    'no-extra-boolean-cast': 'warn',
-    'no-fallthrough': 'warn',
-    'no-func-assign': 'error',
-    'no-global-assign': 'warn',
-    'no-implied-eval': 'warn',
-    'no-inner-declarations': 'warn',
-    'no-invalid-regexp': 'error',
-    'no-irregular-whitespace': 'warn',
-    'no-iterator': 'warn',
-    'no-label-var': 'warn',
-    'no-labels': ['warn', { allowLoop: true, allowSwitch: true }],
-    'no-lone-blocks': 'warn',
-    'no-multi-assign': 'warn',
-    'no-new': 'warn',
-    'no-new-func': 'warn',
-    'no-new-object': 'warn',
-    'no-new-symbol': 'error',
-    'no-obj-calls': 'warn',
-    'no-octal': 'warn',
-    'no-octal-escape': 'warn',
-    'no-proto': 'warn',
-    'no-redeclare': 'warn',
-    'no-return-assign': 'warn',
-    'no-script-url': 'warn',
-    'no-self-assign': 'warn',
-    'no-self-compare': 'warn',
-    'no-sequences': 'warn',
-    'no-shadow-restricted-names': 'warn',
-    'no-sparse-arrays': 'warn',
-    'no-this-before-super': 'warn',
-    'no-throw-literal': 'warn',
-    'no-undef': 'error',
-    'no-unneeded-ternary': 'warn',
-    'no-unreachable': 'warn',
-    'no-unsafe-negation': 'warn',
-    'no-unused-expressions': [
-      'warn',
-      { allowShortCircuit: true, enforceForJSX: true },
-    ],
-    'no-unused-labels': 'warn',
-    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
-    'no-useless-computed-key': 'warn',
-    'no-useless-concat': 'warn',
-    'no-useless-constructor': 'warn',
-    'no-useless-escape': 'warn',
-    'no-useless-rename': 'warn',
-    'no-useless-return': 'warn',
-    'no-var': 'warn',
-    'no-void': 'warn',
-    'no-with': 'error',
-    'object-shorthand': [
-      'error',
-      'always',
-      { ignoreConstructors: false, avoidQuotes: true },
-    ],
-    'prefer-const': [
-      'warn',
-      { destructuring: 'all', ignoreReadBeforeAssign: true },
-    ],
-    'prefer-promise-reject-errors': 'warn',
-    'prefer-rest-params': 'warn',
-    'prefer-spread': 'warn',
-    'unicode-bom': ['warn', 'never'],
-    'use-isnan': 'error',
-    'valid-typeof': 'error',
-    yoda: ['warn', 'never', { exceptRange: true }],
+const globals = require('globals')
+const _import = require('eslint-plugin-import')
 
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      { js: 'never', mjs: 'never', jsx: 'never', ts: 'never', tsx: 'never' },
-    ],
-    'no-restricted-imports': ['error', { paths: ['src'], patterns: ['../*'] }],
-    'no-restricted-modules': ['error', { paths: ['src'], patterns: ['../*'] }],
-    'import/order': [
-      'error',
-      {
-        groups: [
-          'external',
-          'builtin',
-          'internal',
-          'parent',
-          'sibling',
-          'index',
-        ],
+const { fixupPluginRules } = require('@eslint/compat')
+
+module.exports = defineConfig([
+  {
+    languageOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2022,
+
+      parserOptions: {
+        ecmaFeatures: {
+          impliedStrict: true,
+          jsx: true,
+        },
       },
-    ],
-    'import/no-duplicates': 'error',
-    curly: ['error', 'all'],
+
+      // 전역 테스트 심볼은 테스트 전용 블록에서 한정
+      globals: {},
+    },
+
+    plugins: {
+      import: fixupPluginRules({
+        rules: _import.rules,
+        configs: undefined, // configs를 제거하여 circular reference 방지
+      }),
+    },
+
+    rules: {
+      'constructor-super': 'warn',
+      eqeqeq: ['error', 'smart'],
+      'getter-return': 'warn',
+      'new-parens': 'warn',
+      'no-alert': 'off',
+      'no-case-declarations': 'warn',
+      'no-compare-neg-zero': 'error',
+      'no-cond-assign': 'warn',
+      'no-const-assign': 'error',
+
+      'no-constant-condition': [
+        'warn',
+        {
+          checkLoops: false,
+        },
+      ],
+
+      'no-control-regex': 'off',
+      'no-delete-var': 'error',
+      'no-dupe-args': 'error',
+      'no-dupe-class-members': 'error',
+      'no-dupe-keys': 'error',
+      'no-duplicate-case': 'error',
+      'no-empty-character-class': 'warn',
+      'no-empty-pattern': 'warn',
+      'no-eval': 'warn',
+      'no-ex-assign': 'warn',
+      'no-extend-native': 'warn',
+      'no-extra-bind': 'warn',
+      'no-extra-boolean-cast': 'warn',
+      'no-fallthrough': 'warn',
+      'no-func-assign': 'error',
+      'no-global-assign': 'warn',
+      'no-implied-eval': 'warn',
+      'no-inner-declarations': 'warn',
+      'no-invalid-regexp': 'error',
+      'no-irregular-whitespace': 'warn',
+      'no-iterator': 'warn',
+      'no-label-var': 'warn',
+
+      'no-labels': [
+        'warn',
+        {
+          allowLoop: true,
+          allowSwitch: true,
+        },
+      ],
+
+      'no-lone-blocks': 'warn',
+      'no-multi-assign': 'warn',
+      'no-new': 'warn',
+      'no-new-func': 'warn',
+      'no-new-object': 'warn',
+      'no-new-symbol': 'error',
+      'no-obj-calls': 'warn',
+      'no-octal': 'warn',
+      'no-octal-escape': 'warn',
+      'no-proto': 'warn',
+      'no-redeclare': 'warn',
+      'no-return-assign': 'warn',
+      'no-script-url': 'warn',
+      'no-self-assign': 'warn',
+      'no-self-compare': 'warn',
+      'no-sequences': 'warn',
+      'no-shadow-restricted-names': 'warn',
+      'no-sparse-arrays': 'warn',
+      'no-this-before-super': 'warn',
+      'no-throw-literal': 'warn',
+      'no-undef': 'error',
+      'no-unneeded-ternary': 'warn',
+      'no-unreachable': 'warn',
+      'no-unsafe-negation': 'warn',
+
+      'no-unused-expressions': [
+        'warn',
+        {
+          allowShortCircuit: true,
+          enforceForJSX: true,
+        },
+      ],
+
+      'no-unused-labels': 'warn',
+
+      'no-unused-vars': [
+        'error',
+        {
+          ignoreRestSiblings: true,
+        },
+      ],
+
+      'no-useless-computed-key': 'warn',
+      'no-useless-concat': 'warn',
+      'no-useless-constructor': 'warn',
+      'no-useless-escape': 'warn',
+      'no-useless-rename': 'warn',
+      'no-useless-return': 'warn',
+      'no-var': 'warn',
+      'no-void': 'warn',
+      'no-with': 'error',
+
+      'object-shorthand': [
+        'error',
+        'always',
+        {
+          ignoreConstructors: false,
+          avoidQuotes: true,
+        },
+      ],
+
+      'prefer-const': [
+        'warn',
+        {
+          destructuring: 'all',
+          ignoreReadBeforeAssign: true,
+        },
+      ],
+
+      'prefer-promise-reject-errors': 'warn',
+      'prefer-rest-params': 'warn',
+      'prefer-spread': 'warn',
+      'unicode-bom': ['warn', 'never'],
+      'use-isnan': 'error',
+      'valid-typeof': 'error',
+
+      yoda: [
+        'warn',
+        'never',
+        {
+          exceptRange: true,
+        },
+      ],
+
+      'import/extensions': [
+        'error',
+        'ignorePackages',
+        {
+          js: 'never',
+          mjs: 'never',
+          jsx: 'never',
+          ts: 'never',
+          tsx: 'never',
+        },
+      ],
+
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: ['src'],
+          patterns: ['../*'],
+        },
+      ],
+
+      'no-restricted-modules': [
+        'error',
+        {
+          paths: ['src'],
+          patterns: ['../*'],
+        },
+      ],
+
+      'import/order': [
+        'error',
+        {
+          groups: [
+            'external',
+            'builtin',
+            'internal',
+            'parent',
+            'sibling',
+            'index',
+          ],
+        },
+      ],
+
+      'import/no-duplicates': 'error',
+      curly: ['error', 'all'],
+    },
   },
-}
+  {
+    files: ['**/*.{test,spec}.{js,jsx,ts,tsx}', '**/__tests__/**'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
+])

--- a/packages/eslint-config/rules/next.js
+++ b/packages/eslint-config/rules/next.js
@@ -1,3 +1,17 @@
-module.exports = {
-  extends: ['plugin:@next/next/recommended'],
-}
+const { defineConfig } = require('eslint/config')
+
+const js = require('@eslint/js')
+
+const { FlatCompat } = require('@eslint/eslintrc')
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+})
+
+module.exports = defineConfig([
+  {
+    extends: compat.extends('plugin:@next/next/recommended'),
+  },
+])

--- a/packages/eslint-config/rules/prettier.js
+++ b/packages/eslint-config/rules/prettier.js
@@ -1,3 +1,17 @@
-module.exports = {
-  extends: ['prettier'],
-}
+const { defineConfig } = require('eslint/config')
+
+const js = require('@eslint/js')
+
+const { FlatCompat } = require('@eslint/eslintrc')
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+})
+
+module.exports = defineConfig([
+  {
+    extends: compat.extends('prettier'),
+  },
+])

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -1,44 +1,105 @@
-module.exports = {
-  parserOptions: { ecmaFeatures: { jsx: true } },
-  plugins: ['react', 'react-hooks', 'jsx-a11y'],
-  rules: {
-    'jsx-quotes': ['error', 'prefer-double'],
-    'react/jsx-boolean-value': ['error', 'never', { always: [] }],
-    'react/jsx-pascal-case': [
-      'error',
-      {
-        allowAllCaps: true,
-        ignore: [],
+const { defineConfig } = require('eslint/config')
+
+const { fixupPluginRules } = require('@eslint/compat')
+
+// React plugin에서 필요한 부분만 추출
+const reactPlugin = require('eslint-plugin-react')
+const reactHooksPlugin = require('eslint-plugin-react-hooks')
+const jsxA11yPlugin = require('eslint-plugin-jsx-a11y')
+
+module.exports = defineConfig([
+  {
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
       },
-    ],
-    'react/no-string-refs': 'error',
-    'react/no-unknown-property': 'error',
-    'react/jsx-key': [
-      'error',
-      {
-        checkFragmentShorthand: true,
-        checkKeyMustBeforeSpread: true,
+    },
+
+    plugins: {
+      react: fixupPluginRules({
+        rules: reactPlugin.rules,
+        configs: undefined, // configs를 제거하여 circular reference 방지
+      }),
+      'react-hooks': fixupPluginRules({
+        rules: reactHooksPlugin.rules,
+        configs: undefined,
+      }),
+      'jsx-a11y': fixupPluginRules({
+        rules: jsxA11yPlugin.rules,
+        configs: undefined,
+      }),
+    },
+
+    rules: {
+      'jsx-quotes': ['error', 'prefer-double'],
+
+      'react/jsx-boolean-value': [
+        'error',
+        'never',
+        {
+          always: [],
+        },
+      ],
+
+      'react/jsx-pascal-case': [
+        'error',
+        {
+          allowAllCaps: true,
+          ignore: [],
+        },
+      ],
+
+      'react/no-string-refs': 'error',
+      'react/no-unknown-property': 'error',
+
+      'react/jsx-key': [
+        'error',
+        {
+          checkFragmentShorthand: true,
+          checkKeyMustBeforeSpread: true,
+        },
+      ],
+
+      'react/jsx-curly-spacing': [
+        'error',
+        {
+          when: 'never',
+
+          children: {
+            when: 'always',
+          },
+        },
+      ],
+
+      'react/jsx-filename-extension': [
+        'warn',
+        {
+          extensions: ['.js', '.jsx', '.tsx'],
+        },
+      ],
+
+      'react/jsx-no-constructed-context-values': 'error',
+
+      'react/jsx-curly-brace-presence': [
+        'error',
+        {
+          props: 'never',
+          children: 'never',
+        },
+      ],
+
+      'react/no-find-dom-node': 'warn',
+      'react/self-closing-comp': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+    },
+
+    settings: {
+      react: {
+        version: 'detect',
       },
-    ],
-    'react/jsx-curly-spacing': [
-      'error',
-      { when: 'never', children: { when: 'always' } },
-    ],
-    'react/jsx-filename-extension': [
-      'warn',
-      { extensions: ['.js', '.jsx', '.tsx'] },
-    ],
-    'react/jsx-no-constructed-context-values': 'error',
-    'react/jsx-curly-brace-presence': [
-      'error',
-      { props: 'never', children: 'never' },
-    ],
-    'react/no-find-dom-node': 'warn',
-    'react/self-closing-comp': 'error',
-    'react-hooks/exhaustive-deps': 'error',
-    'react-hooks/rules-of-hooks': 'error',
+    },
   },
-  settings: {
-    react: { version: 'detect' },
-  },
-}
+])

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -1,53 +1,79 @@
-module.exports = {
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      extends: ['plugin:import/typescript'],
-      parser: '@typescript-eslint/parser',
+const { defineConfig } = require('eslint/config')
+
+const { fixupPluginRules } = require('@eslint/compat')
+
+const tsParser = require('@typescript-eslint/parser')
+const typescriptEslint = require('@typescript-eslint/eslint-plugin')
+const unusedImports = require('eslint-plugin-unused-imports')
+
+module.exports = defineConfig([
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.d.ts'],
+
+    languageOptions: {
+      parser: tsParser,
+
       parserOptions: {
-        // eslint-plugin-react@7.32.2 accesses superTypeParameters, which is deprecated by
-        // typescript-estree and prints a warning by default
         suppressDeprecatedPropertyWarnings: true,
       },
-      plugins: ['@typescript-eslint', 'unused-imports'],
-      rules: {
-        '@typescript-eslint/consistent-type-imports': ['warn'],
-        '@typescript-eslint/consistent-type-assertions': [
-          'warn',
-          { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' },
-        ],
-        '@typescript-eslint/no-extra-non-null-assertion': 'warn',
+    },
 
-        // Overrides
-        'no-dupe-class-members': 'off',
-        '@typescript-eslint/no-dupe-class-members': 'warn',
+    plugins: {
+      '@typescript-eslint': fixupPluginRules({
+        rules: typescriptEslint.rules,
+        configs: undefined, // configs를 제거하여 circular reference 방지
+      }),
+      'unused-imports': fixupPluginRules({
+        rules: unusedImports.rules,
+        configs: undefined,
+      }),
+    },
 
-        'no-redeclare': 'off',
-        '@typescript-eslint/no-redeclare': 'warn',
+    rules: {
+      '@typescript-eslint/consistent-type-imports': ['warn'],
 
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
-        'unused-imports/no-unused-vars': [
-          'warn',
-          {
-            vars: 'all',
-            args: 'none',
-            ignoreRestSiblings: true,
-            caughtErrors: 'all',
-          },
-        ],
-        'unused-imports/no-unused-imports': 'error',
-        'no-useless-constructor': 'off',
-        '@typescript-eslint/no-useless-constructor': 'warn',
-        'no-undef': 'off',
-      },
-      settings: {
-        'import/extensions': ['.js', '.jsx', '.ts', '.tsx', '.d.ts'],
-        'import/parsers': {
-          '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
+      '@typescript-eslint/consistent-type-assertions': [
+        'warn',
+        {
+          assertionStyle: 'as',
+          objectLiteralTypeAssertions: 'allow',
         },
-        'import/resolver': { typescript: {} },
+      ],
+
+      '@typescript-eslint/no-extra-non-null-assertion': 'warn',
+      'no-dupe-class-members': 'off',
+      '@typescript-eslint/no-dupe-class-members': 'warn',
+      'no-redeclare': 'off',
+      '@typescript-eslint/no-redeclare': 'warn',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+
+      'unused-imports/no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          args: 'none',
+          ignoreRestSiblings: true,
+          caughtErrors: 'all',
+        },
+      ],
+
+      'unused-imports/no-unused-imports': 'error',
+      'no-useless-constructor': 'off',
+      '@typescript-eslint/no-useless-constructor': 'warn',
+      'no-undef': 'off',
+    },
+
+    settings: {
+      'import/extensions': ['.js', '.jsx', '.ts', '.tsx', '.d.ts'],
+
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
+      },
+
+      'import/resolver': {
+        typescript: {},
       },
     },
-  ],
-}
+  },
+])

--- a/packages/eslint-config/web.js
+++ b/packages/eslint-config/web.js
@@ -1,11 +1,25 @@
-module.exports = {
-  extends: [
-    './rules/base.js',
-    './rules/react.js',
-    './rules/typescript.js',
-    './rules/prettier.js',
-  ],
-  env: { browser: true },
-  globals: { window: true, fetch: true },
-  rules: { curly: ['error', 'all'] },
-}
+const { defineConfig } = require('eslint/config')
+
+const globals = require('globals')
+
+const base = require('./rules/base.js')
+const react = require('./rules/react.js')
+const typescript = require('./rules/typescript.js')
+const prettier = require('./rules/prettier.js')
+
+module.exports = defineConfig([
+  ...base,
+  ...react,
+  ...typescript,
+  ...prettier,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+    rules: {
+      curly: ['error', 'all'],
+    },
+  },
+])

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,23 +672,27 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@channel.io/eslint-config@workspace:packages/eslint-config"
   dependencies:
+    "@eslint/compat": "npm:^1.3.2"
+    "@eslint/eslintrc": "npm:^3.3.1"
+    "@eslint/js": "npm:^9.34.0"
     "@next/eslint-plugin-next": "npm:^14.2.29"
-    "@rushstack/eslint-patch": "npm:^1.11.0"
+    "@rushstack/eslint-patch": "npm:^1.12.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.32.1"
     "@typescript-eslint/parser": "npm:^8.32.1"
-    eslint: "npm:^8.57.1"
+    eslint: "npm:^9.34.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-import-resolver-node: "npm:^0.3.9"
     eslint-import-resolver-typescript: "npm:^3.10.1"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^4.6.2"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-unused-imports: "npm:^4.1.4"
+    globals: "npm:^16.3.0"
     prettier: "npm:^3.5.3"
     typescript: "npm:^4.9.5"
   peerDependencies:
-    eslint: ">=8.10"
+    eslint: ">=9"
     prettier: ">=3"
   languageName: unknown
   linkType: soft
@@ -851,6 +855,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/regexpp@npm:^4.12.1":
+  version: 4.12.1
+  resolution: "@eslint-community/regexpp@npm:4.12.1"
+  checksum: a03d98c246bcb9109aec2c08e4d10c8d010256538dcb3f56610191607214523d4fb1b00aa81df830b6dffb74c5fa0be03642513a289c567949d3e550ca11cdf6
+  languageName: node
+  linkType: hard
+
+"@eslint/compat@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@eslint/compat@npm:1.3.2"
+  peerDependencies:
+    eslint: ^8.40 || 9
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 9b95b49ee74c50adf8f0e45066b471bc76842c43d4721727ff93d186745bdd1679d18420c992a05eab3bb41762672cd3faa5c56c99325dbb97200f7533cbd2bf
+  languageName: node
+  linkType: hard
+
+"@eslint/config-array@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@eslint/config-array@npm:0.21.0"
+  dependencies:
+    "@eslint/object-schema": "npm:^2.1.6"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^3.1.2"
+  checksum: 0ea801139166c4aa56465b309af512ef9b2d3c68f9198751bbc3e21894fe70f25fbf26e1b0e9fffff41857bc21bfddeee58649ae6d79aadcd747db0c5dca771f
+  languageName: node
+  linkType: hard
+
+"@eslint/config-helpers@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@eslint/config-helpers@npm:0.3.1"
+  checksum: f6c5b3a0b76a0d7d84cc93e310c259e6c3e0792ddd0a62c5fc0027796ffae44183432cb74b2c2b1162801ee1b1b34a6beb5d90a151632b4df7349f994146a856
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@eslint/core@npm:0.15.2"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: c17a6dc4f5a6006ecb60165cc38bcd21fefb4a10c7a2578a0cfe5813bbd442531a87ed741da5adab5eb678e8e693fda2e2b14555b035355537e32bcec367ea17
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^2.1.4":
   version: 2.1.4
   resolution: "@eslint/eslintrc@npm:2.1.4"
@@ -868,10 +918,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/eslintrc@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@eslint/eslintrc@npm:3.3.1"
+  dependencies:
+    ajv: "npm:^6.12.4"
+    debug: "npm:^4.3.2"
+    espree: "npm:^10.0.1"
+    globals: "npm:^14.0.0"
+    ignore: "npm:^5.2.0"
+    import-fresh: "npm:^3.2.1"
+    js-yaml: "npm:^4.1.0"
+    minimatch: "npm:^3.1.2"
+    strip-json-comments: "npm:^3.1.1"
+  checksum: b0e63f3bc5cce4555f791a4e487bf999173fcf27c65e1ab6e7d63634d8a43b33c3693e79f192cbff486d7df1be8ebb2bd2edc6e70ddd486cbfa84a359a3e3b41
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:8.57.1":
   version: 8.57.1
   resolution: "@eslint/js@npm:8.57.1"
   checksum: b489c474a3b5b54381c62e82b3f7f65f4b8a5eaaed126546520bf2fede5532a8ed53212919fed1e9048dcf7f37167c8561d58d0ba4492a4244004e7793805223
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:9.34.0, @eslint/js@npm:^9.34.0":
+  version: 9.34.0
+  resolution: "@eslint/js@npm:9.34.0"
+  checksum: 53f1bfd2a374683d9382a6850354555f6e89a88416c34a5d34e9fbbaf717e97c2b06300e8f93e5eddba8bda8951ccab7f93a680e56ded1a3d21d526019e69bab
+  languageName: node
+  linkType: hard
+
+"@eslint/object-schema@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "@eslint/object-schema@npm:2.1.6"
+  checksum: b8cdb7edea5bc5f6a96173f8d768d3554a628327af536da2fc6967a93b040f2557114d98dbcdbf389d5a7b290985ad6a9ce5babc547f36fc1fde42e674d11a56
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@eslint/plugin-kit@npm:0.3.5"
+  dependencies:
+    "@eslint/core": "npm:^0.15.2"
+    levn: "npm:^0.4.1"
+  checksum: c178c1b58c574200c0fd125af3e4bc775daba7ce434ba6d1eeaf9bcb64b2e9fea75efabffb3ed3ab28858e55a016a5efa95f509994ee4341b341199ca630b89e
+  languageName: node
+  linkType: hard
+
+"@humanfs/core@npm:^0.19.1":
+  version: 0.19.1
+  resolution: "@humanfs/core@npm:0.19.1"
+  checksum: aa4e0152171c07879b458d0e8a704b8c3a89a8c0541726c6b65b81e84fd8b7564b5d6c633feadc6598307d34564bd53294b533491424e8e313d7ab6c7bc5dc67
+  languageName: node
+  linkType: hard
+
+"@humanfs/node@npm:^0.16.6":
+  version: 0.16.7
+  resolution: "@humanfs/node@npm:0.16.7"
+  dependencies:
+    "@humanfs/core": "npm:^0.19.1"
+    "@humanwhocodes/retry": "npm:^0.4.0"
+  checksum: 9f83d3cf2cfa37383e01e3cdaead11cd426208e04c44adcdd291aa983aaf72d7d3598844d2fe9ce54896bb1bf8bd4b56883376611c8905a19c44684642823f30
   languageName: node
   linkType: hard
 
@@ -897,6 +1005,13 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "@humanwhocodes/retry@npm:0.4.3"
+  checksum: 3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
   languageName: node
   linkType: hard
 
@@ -1331,10 +1446,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/eslint-patch@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@rushstack/eslint-patch@npm:1.11.0"
-  checksum: abea8d8cf2f4f50343f74abd6a8173c521ddd09b102021f5aa379ef373c40af5948b23db0e87eca1682e559e09d97d3f0c48ea71edad682c6bf72b840c8675b3
+"@rushstack/eslint-patch@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@rushstack/eslint-patch@npm:1.12.0"
+  checksum: 1e567656d92632c085a446f40767bc451caffe1131e8d6a7a3e8f3e3f4167f5f29744a84c709f2440f299442d4bc68ff773784462166800b8c09c0e08042415b
   languageName: node
   linkType: hard
 
@@ -1413,6 +1528,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/estree@npm:^1.0.6":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.9
   resolution: "@types/graceful-fs@npm:4.1.9"
@@ -1444,6 +1566,13 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
   checksum: 1647fd402aced5b6edac87274af14ebd6b3a85447ef9ad11853a70fd92a98d35f81a5d3ea9fcb5dbb5834e800c6e35b64475e33fcae6bfa9acc70d61497c54ee
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
   languageName: node
   linkType: hard
 
@@ -1815,6 +1944,15 @@ __metadata:
   peerDependencies:
     acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: 4c54868fbef3b8d58927d5e33f0a4de35f59012fe7b12cf9dfbb345fb8f46607709e1c4431be869a23fb63c151033d84c4198fa9f79385cec34fcb1dd53974c1
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.15.0":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
+  bin:
+    acorn: bin/acorn
+  checksum: dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
   languageName: node
   linkType: hard
 
@@ -2632,7 +2770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -3210,12 +3348,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^4.6.2":
-  version: 4.6.2
-  resolution: "eslint-plugin-react-hooks@npm:4.6.2"
+"eslint-plugin-react-hooks@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
   peerDependencies:
-    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-  checksum: 4844e58c929bc05157fb70ba1e462e34f1f4abcbc8dd5bbe5b04513d33e2699effb8bca668297976ceea8e7ebee4e8fc29b9af9d131bcef52886feaa2308b2cc
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+  checksum: 1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
   languageName: node
   linkType: hard
 
@@ -3270,6 +3408,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "eslint-scope@npm:8.4.0"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
+  languageName: node
+  linkType: hard
+
 "eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
@@ -3281,6 +3429,13 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
   languageName: node
   linkType: hard
 
@@ -3332,6 +3487,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint@npm:^9.34.0":
+  version: 9.34.0
+  resolution: "eslint@npm:9.34.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.2.0"
+    "@eslint-community/regexpp": "npm:^4.12.1"
+    "@eslint/config-array": "npm:^0.21.0"
+    "@eslint/config-helpers": "npm:^0.3.1"
+    "@eslint/core": "npm:^0.15.2"
+    "@eslint/eslintrc": "npm:^3.3.1"
+    "@eslint/js": "npm:9.34.0"
+    "@eslint/plugin-kit": "npm:^0.3.5"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.2"
+    "@types/estree": "npm:^1.0.6"
+    "@types/json-schema": "npm:^7.0.15"
+    ajv: "npm:^6.12.4"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^8.4.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+    espree: "npm:^10.4.0"
+    esquery: "npm:^1.5.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.2"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: ba3e54fa0c8ed23d062f91519afaae77fed922a6c4d76130b6cd32154bcb406aaea4b3c5ed88e0be40828c1d5b6921592f3947dbdc5e2043de6bd7aa341fe5ea
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.1, espree@npm:^10.4.0":
+  version: 10.4.0
+  resolution: "espree@npm:10.4.0"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
+  languageName: node
+  linkType: hard
+
 "espree@npm:^9.6.0, espree@npm:^9.6.1":
   version: 9.6.1
   resolution: "espree@npm:9.6.1"
@@ -3359,6 +3575,15 @@ __metadata:
   dependencies:
     estraverse: "npm:^5.1.0"
   checksum: a084bd049d954cc88ac69df30534043fb2aee5555b56246493f42f27d1e168f00d9e5d4192e46f10290d312dc30dc7d58994d61a609c579c1219d636996f9213
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "esquery@npm:1.6.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: cb9065ec605f9da7a76ca6dadb0619dfb611e37a81e318732977d90fab50a256b95fee2d925fba7c2f3f0523aa16f91587246693bc09bc34d5a59575fe6e93d2
   languageName: node
   linkType: hard
 
@@ -3536,6 +3761,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: "npm:^4.0.0"
+  checksum: 9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -3582,6 +3816,16 @@ __metadata:
     keyv: "npm:^4.5.3"
     rimraf: "npm:^3.0.2"
   checksum: b76f611bd5f5d68f7ae632e3ae503e678d205cf97a17c6ab5b12f6ca61188b5f1f7464503efae6dc18683ed8f0b41460beb48ac4b9ac63fe6201296a91ba2f75
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.4"
+  checksum: 2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
   languageName: node
   linkType: hard
 
@@ -3887,6 +4131,20 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: d3c11aeea898eb83d5ec7a99508600fbe8f83d2cf00cbb77f873dbf2bcb39428eff1b538e4915c993d8a3b3473fa71eeebfe22c9bb3a3003d1e26b1f2c8a42cd
+  languageName: node
+  linkType: hard
+
+"globals@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "globals@npm:14.0.0"
+  checksum: b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
+  languageName: node
+  linkType: hard
+
+"globals@npm:^16.3.0":
+  version: 16.3.0
+  resolution: "globals@npm:16.3.0"
+  checksum: c62dc20357d1c0bf2be4545d6c4141265d1a229bf1c3294955efb5b5ef611145391895e3f2729f8603809e81b30b516c33e6c2597573844449978606aad6eb38
   languageName: node
   linkType: hard
 
@@ -5196,7 +5454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3":
+"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:


### PR DESCRIPTION
* feat: update to eslint 9

* refactor(eslint-config): 중복된 curly 규칙 제거

- packages/eslint-config/default.js에서 curly: ['error', 'all'] 제거
- 동일한 규칙이 packages/eslint-config/rules/base.js에 정의되어 있어 중복 해결
- 기능적으로 동일하지만 코드 중복 제거로 더 깔끔한 구조

* refactor(eslint-config): Flat Config에서 문자열 extends를 require로 변경

- eslint.config.js에서 { extends: './node.js' } 방식 제거
- module.exports = defineConfig(require('./node.js'))로 직접 불러오기
- 런타임에서 문자열 extends는 지원되지 않는 문제 해결

* feat(eslint-config): 프리릴리스 배포 안전장치 및 엔진 제약 추가

- publishConfig에 alpha 태그와 public access 설정
- engines에 Node.js >=18.18 || >=20 조건 명시
- ESLint 9가 요구하는 Node 버전 조건 준수
- alpha 버전 배포 시 실수로 latest 태그로 배포되는 것을 방지

* fix(eslint-config): ESLint peerDependency 버전 범위 제한

- eslint peerDependency를 '>=9'에서 '>=9 <10'으로 수정
- ESLint v10에서 발생할 수 있는 예기치 않은 브레이킹 체인지 방지
- 더 안전한 버전 범위 관리로 호환성 보장

* fix(eslint-config): jest 전역 변수를 테스트 파일로 범위 제한

- 기본 globals에서 jest 전역 변수 제거하여 소스 코드 누출 방지
- 테스트 파일(**/*.{test,spec}.{js,jsx,ts,tsx}, **/__tests__/**)에서만 jest 전역 허용
- describe/it 오타/오용이 빌드 소스에서 검출되지 않는 문제 해결
- 더 엄격한 코드 품질 관리 및 테스트 격리 보장

* fix(eslint-config): 중복된 브라우저 전역 변수 제거

- web.js에서 window: true, fetch: true 제거
- globals.browser에 이미 포함되어 있어 중복됨
- true 설정으로 인한 가변(writable) 처리 문제 해결
- 실수로 전역 변수를 재할당하는 것을 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - ESLint 구성을 Flat/defineConfig 기반으로 전면 재구성하고 규칙 세트를 모듈화해 일관되게 병합합니다.
  - 환경/글로벌 설정을 languageOptions.globals로 통합하고 테스트 전용 설정을 추가합니다.
  - React/TypeScript/Next/Prettier 규칙 구성을 최신 방식으로 정리합니다.
- Chores
  - 버전 3.0.0으로 업데이트.
  - Node >=18.18 또는 >=20 요구, ESLint 피어 의존성 >=9 <10로 상향.
  - 관련 의존성 업데이트 및 공개 배포 설정 적용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->